### PR TITLE
Fix Dutch spelling mistakes / Anglicisms

### DIFF
--- a/resources-dut/strings/strings.xml
+++ b/resources-dut/strings/strings.xml
@@ -66,7 +66,7 @@
 	<string id="HeartRateLive5s">Hartslag (Live 5s)</string>
 	<string id="Battery">Batterij</string>
 	<string id="BatteryHidePercentage">Batterij (Verberg Percentage)</string>
-	<string id="Notifications">Notificaties</string>
+	<string id="Notifications">Meldingen</string>
 	<string id="Calories">Calorien</string>
 	<string id="Distance">Afstand</string>
 	<string id="Alarms">Alarmen</string>
@@ -75,7 +75,7 @@
 	<string id="Bluetooth">Bluetooth</string>
 	<string id="BluetoothOrNotifications">Bluetooth/Notificaties</string>
 	<string id="SunriseSunset">Zonopkomst / -Ondergang</string>
-	<string id="Weather">Weeer</string>
+	<string id="Weather">Weer</string>
 	<string id="Humidity">Vochtigheid</string>
 	<string id="Pressure">Luchtdruk</string>
 


### PR DESCRIPTION
 - 'notificaties' is a too literal translation. 'Meldingen' is more common in Dutch.
- spelling mistake in 'Wee(e)r' fixed